### PR TITLE
Add options for square meter price

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ Here are the most important variable to look at when using this scrapper:
 **Python requirements**
 
  5. Install Python3 and Python3 pip
- 6. Install all the Python3 necessary packages `pip3 install BeautifulSoup4 requests sqlalchemy slackclient`
+ 6. Install all the Python3 necessary packages `pip3 install -r requirements.txt`
  7. Grant execution permission on the scrapper `chmod +x scrapper.py`
  8. Run it and your good to go `./scrapper.py`
+
+ It is recommended to create a virtual environment using virtualenv for this.
 
 **Tips to launch the script**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+BeautifulSoup4
+requests
+sqlalchemy
+slackclient

--- a/scrapper.py
+++ b/scrapper.py
@@ -20,14 +20,22 @@ DEFAULT_MIN_SIZE = 10
 def matchesFilters(result):
     options = settings.SEARCH_OPTIONS
 
-    if result.price > options.get('maxPrice', DEFAULT_MAX_PRICE) or result.price < options.get('minPrice', DEFAULT_MIN_PRICE):
+    if not options.get('minPrice', DEFAULT_MIN_PRICE) < result.price < options.get('maxPrice', DEFAULT_MAX_PRICE):
         return False
 
-    if result.rooms > options.get('maxRooms', DEFAULT_MAX_ROOMS) or result.rooms < options.get('minRooms', DEFAULT_MIN_ROOMS):
+    if not options.get('minRooms', DEFAULT_MIN_ROOMS) < result.rooms < options.get('maxRooms', DEFAULT_MAX_ROOMS):
         return False
 
-    if result.size > options.get('maxSize', DEFAULT_MAX_SIZE) or result.size < options.get('minSize', DEFAULT_MIN_SIZE):
+    if not options.get('minSize', DEFAULT_MIN_SIZE) < result.size < options.get('maxSize', DEFAULT_MAX_SIZE):
         return False
+
+
+    minSquareMeterPrice = options.get('minSquareMeterPrice')
+    maxSquareMeterPrice = options.get('maxSquareMeterPrice')
+    # Optional arguments, we only do this if the user cares about both the minimum and maximum m2 price
+    if minSquareMeterPrice and maxSquareMeterPrice:
+        if not minSquareMeterPrice < round(result.price/result.size) < maxSquareMeterPrice:
+            return False
 
     # If we have prefered neighboorhoods we check if the location is in one of them
     if len(settings.PREFERED_NEIGHBOORHOODS) > 0:

--- a/scrapper.py
+++ b/scrapper.py
@@ -15,6 +15,8 @@ DEFAULT_MAX_ROOMS = 13
 DEFAULT_MIN_ROOMS = 1
 DEFAULT_MAX_SIZE = 400
 DEFAULT_MIN_SIZE = 10
+DEFAULT_MIN_SQUARE_METER_PRICE = 50
+DEFAULT_MAX_SQUARE_METER_PRICE = 1000
 
 # Returns True if the given result matches the given search options
 def matchesFilters(result):
@@ -29,13 +31,8 @@ def matchesFilters(result):
     if not options.get('minSize', DEFAULT_MIN_SIZE) < result.size < options.get('maxSize', DEFAULT_MAX_SIZE):
         return False
 
-
-    minSquareMeterPrice = options.get('minSquareMeterPrice')
-    maxSquareMeterPrice = options.get('maxSquareMeterPrice')
-    # Optional arguments, we only do this if the user cares about both the minimum and maximum m2 price
-    if minSquareMeterPrice and maxSquareMeterPrice:
-        if not minSquareMeterPrice < round(result.price/result.size) < maxSquareMeterPrice:
-            return False
+    if not options.get('minSquareMeterPrice', DEFAULT_MIN_SQUARE_METER_PRICE) < round(result.price/result.size) < options.get('maxSquareMeterPrice', DEFAULT_MAX_SQUARE_METER_PRICE):
+        return False
 
     # If we have prefered neighboorhoods we check if the location is in one of them
     if len(settings.PREFERED_NEIGHBOORHOODS) > 0:

--- a/settings.py
+++ b/settings.py
@@ -10,8 +10,8 @@ SEARCH_OPTIONS = {
     'minBedrooms' : 1, # minimum number of bedrooms, the maximum can't be set as it's not appearing in the blocket results
     'minSize' : 20, # minimum size in square meters
     'maxSize' : 60, # maximum size in square meters
-    'minSquareMeterPrice': None,
-    'maxSquareMeterPrice': None,
+    'minSquareMeterPrice': None, # minimum acceptable m2 price
+    'maxSquareMeterPrice': None, # maximum acceptable m2 price
 }
 
 # The city to search in Blocket.se

--- a/settings.py
+++ b/settings.py
@@ -9,7 +9,9 @@ SEARCH_OPTIONS = {
     'maxRooms' : 3, # maximum number of rooms
     'minBedrooms' : 1, # minimum number of bedrooms, the maximum can't be set as it's not appearing in the blocket results
     'minSize' : 20, # minimum size in square meters
-    'maxSize' : 60 # maximum size in square meters
+    'maxSize' : 60, # maximum size in square meters
+    'minSquareMeterPrice': None,
+    'maxSquareMeterPrice': None,
 }
 
 # The city to search in Blocket.se


### PR DESCRIPTION
I thought it might be interesting for a buyer to make sure that they don't pay too much for too little space, so I added options for specifying the maximum m2 price (and minimum) a buyer is willing to pay in rent. This is a completely optional filtering option which is only performed if specified by the user so it shouldn't interfere with the normal usage.

Also:

- Refactored the requirements to its own file and updated the README
- Rewrote the conditionals in the filtering for a more pythonic feel

Note: Right now it requires for a user to *both* specify a minimum and maximum m2 price. Would you like it some other way? 😄 (Granted that you'd like this PR, that is).